### PR TITLE
[Complete Checking] Add initial content for the "Enable Complete Concurrency Checking" section.

### DIFF
--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -4,13 +4,13 @@ Identify, understand, and address common problems you'll encounter while
 working with Swift concurrency.
 
 The data isolation guarantees made by the compiler affect all Swift code.
-This means strict concurrency checking can surface latent issues,
+This means complete concurrency checking can surface latent issues,
 even in Swift 5 code that doesn't use any concurrency language features
 directly.
 And, with the Swift 6 language mode is on, some of these potential issues
 can become errors.
 
-After enabling strict checking, many projects can contain a large
+After enabling complete checking, many projects can contain a large
 number of warnings and errors.
 _Don't_ get overwhelmed!
 Most of these can be tracked down to a much smaller set of root causes.

--- a/Guide.docc/CompleteChecking.md
+++ b/Guide.docc/CompleteChecking.md
@@ -1,0 +1,78 @@
+# Enabling Complete Concurrency Checking
+
+Incrementally address data-race safety issues by enabling diagnostics as warnings in your project.
+
+Data-race safety in the Swift 6 language mode is designed for incremental
+migration. You can address data-race safety issues in your projects
+module-by-module, and you can enable the compiler's actor isolation and
+`Sendable` checking as warnings in the Swift 5 language mode, allowing you to
+assess your progress toward eliminating data races before turning on the
+Swift 6 language mode.
+
+Complete data-race safety checking can be enabled as warnings in the Swift 5
+language mode using the `-strict-concurrency` compiler flag.
+
+## Using the Swift compiler
+
+To enable complete concurrency checking when running `swift` or `swiftc`
+directly at the command line, pass `-strict-concurrency=complete`:
+
+```
+~ swift -strict-concurrency=complete main.swift
+```
+
+## Using SwiftPM
+
+### In a SwiftPM command-line invocation
+
+`-strict-concurrency=complete` can be passed in a Swift package manager
+command-line invocation using the `-Xswiftc` flag:
+
+```
+~ swift build -Xswiftc -strict-concurrency=complete
+~ swift test -Xswiftc -strict-concurrency=complete
+```
+
+This can be useful to gauge the amount of concurrency warnings before adding
+the flag permanently in the package manifest as described in the following
+section.
+
+### In a SwiftPM package manifest
+
+To enable complete concurrency checking for a target in a Swift package using
+Swift 5.9 or Swift 5.10 tools, use [`SwiftSetting.enableExperimentalFeature`](https://developer.apple.com/documentation/packagedescription/swiftsetting/enableexperimentalfeature(_:_:))
+in the Swift settings for the given target:
+
+```swift
+.target(
+  name: "MyTarget",
+  swiftSettings: [
+    .enableExperimentalFeature("StrictConcurrency")
+  ]
+)
+```
+
+When using Swift 6.0 tools or later, use [`SwiftSetting.enableUpcomingFeature`](https://developer.apple.com/documentation/packagedescription/swiftsetting/enableupcomingfeature(_:_:))
+in the Swift settings for the given target:
+
+```swift
+.target(
+  name: "MyTarget",
+  swiftSettings: [
+    .enableUpcomingFeature("StrictConcurrency")
+  ]
+)
+```
+
+## Using Xcode
+
+To enable complete concurrency checking in an Xcode project, set the
+"Strict Concurrency Checking" setting to "Complete" in the Xcode build
+settings. Alternatively, you can set `SWIFT_STRICT_CONCURRENCY` to `complete`
+in an xcconfig file:
+
+```
+// In a Settings.xcconfig
+
+SWIFT_STRICT_CONCURRENCY = complete;
+```

--- a/Guide.docc/MigrationGuide.md
+++ b/Guide.docc/MigrationGuide.md
@@ -34,7 +34,7 @@ provide concepts and practical help to ease the migration.
 Here you will find articles and code examples that will:
 
 - Explain the concepts used by Swift's data-race safety model.
-- Help you enable strict concurrency checking with Swift 5 projects.
+- Help you enable complete concurrency checking with Swift 5 projects.
 - Provide techniques for incremental adoption.
 - Present strategies to resolve common problems.
 
@@ -44,6 +44,6 @@ Existing projects will not switch to this mode without configuration changes.
 ## Topics
 
 - <doc:DataRaceSafety>
-- <doc:StrictChecking>
+- <doc:CompleteChecking>
 - <doc:IncrementalAdoption>
 - <doc:CommonProblems>

--- a/Guide.docc/StrictChecking.md
+++ b/Guide.docc/StrictChecking.md
@@ -1,3 +1,0 @@
-# Strict Concurrency Checking
-
-abc


### PR DESCRIPTION
This content is just copied over from https://www.swift.org/documentation/concurrency/, which will be subsumed by this guide.