### PR TITLE
Package skeleton

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,44 @@
+// swift-tools-version: 5.10
+
+import PackageDescription
+
+let package = Package(
+    name: "MigrationGuide",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .watchOS(.v6),
+        .tvOS(.v13),
+        .macCatalyst(.v13),
+        .visionOS(.v1),
+    ],
+    products: [
+        .library(
+            name: "FullyMigratedModule",
+            targets: [
+                "FullyMigratedModule",
+                "MigrationInProgressModule",
+            ]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "FullyMigratedModule"
+        ),
+        .target(
+            name: "MigrationInProgressModule",
+            dependencies: ["FullyMigratedModule"]
+        ),
+    ],
+    swiftLanguageVersions: [.v5]
+)
+
+let swiftSettings: [SwiftSetting] = [
+    .enableExperimentalFeature("StrictConcurrency")
+]
+
+for target in package.targets {
+    var settings = target.swiftSettings ?? []
+    settings.append(contentsOf: swiftSettings)
+    target.swiftSettings = settings
+}

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,0 +1,43 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "MigrationGuide",
+    platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .watchOS(.v6),
+        .tvOS(.v13),
+        .macCatalyst(.v13),
+        .visionOS(.v1),
+    ],
+    products: [
+        .library(
+            name: "FullyMigratedModule",
+            targets: [
+                "FullyMigratedModule",
+                "MigrationInProgressModule",
+            ]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "FullyMigratedModule"
+        ),
+        .target(
+            name: "MigrationInProgressModule",
+            dependencies: ["FullyMigratedModule"]
+        ),
+    ],
+    swiftLanguageVersions: [.v6]
+)
+
+let swiftSettings: [SwiftSetting] = [
+]
+
+for target in package.targets {
+    var settings = target.swiftSettings ?? []
+    settings.append(contentsOf: swiftSettings)
+    target.swiftSettings = settings
+}

--- a/Sources/FullyMigratedModule/FullyMigratedModule.swift
+++ b/Sources/FullyMigratedModule/FullyMigratedModule.swift
@@ -1,0 +1,8 @@
+/// An example of a struct with only `Sendable` properties.
+///
+/// This type is implicitly-`Sendable` within its defining module.
+public struct ColorComponents {
+    public let red: Float
+    public let green: Float
+    public let blue: Float
+}

--- a/Sources/MigrationInProgressModule/MigrationInProgressModule.swift
+++ b/Sources/MigrationInProgressModule/MigrationInProgressModule.swift
@@ -1,0 +1,7 @@
+import FullyMigratedModule
+
+func captureNonSendable(argument: ColorComponents) {
+    Task {
+        print(argument)
+    }
+}


### PR DESCRIPTION
Defines a really simple package with two modules.

- `FullyMigratedModule`: a target that has moved to Swift 6 mode
- `MigrationInProgressModule`: a target that has begun enabling complete checking, but still has issues

This includes two package manifest files to workaround a problem I ran into with the May 25 development snapshot.

Because I am deliberately introducing warnings for Swift 5, this currently fails to build with 6. I haven't thought hard about how to handle this yet, but figured the work was still worthwhile.