### PR TITLE
Remove the default code listing language

### DIFF
--- a/Guide.docc/Info.plist
+++ b/Guide.docc/Info.plist
@@ -6,8 +6,6 @@
 	<string>Swift 6 Concurrency Migration Guide</string>
 	<key>CFBundleIdentifier</key>
 	<string>org.swift.migration.6</string>
-	<key>CDDefaultCodeListingLanguage</key>
-	<string>swift</string>
 	<key>CDDefaultModuleKind</key>
 	<string></string>
 </dict>


### PR DESCRIPTION
I originally just copied this from TSPL, since it seemed appropriate. But, it has the side-effect of interpreting the error/warning output as Swift code. Unless *those* fences use some kind of dummy opt-out value, they will be incorrectly highlighted.