### PR TITLE
Missing Language, typo

### DIFF
--- a/Guide.docc/DataRaceSafety.md
+++ b/Guide.docc/DataRaceSafety.md
@@ -318,7 +318,6 @@ class Chicken: Feedable {
 // inherited isolation only applies within the extension
 extension Pirate: Feedable {
 }
-
 ```
 
 A protocol's requirements themselves can also be isolated.
@@ -354,7 +353,7 @@ isolation being statically defined by its type.
 This mechanism may sound complex, but in practice it allows very natural
 behaviors.
 
-```
+```swift
 @MainActor
 func eat(food: Pineapple) {
     // the static isolation of this function's declaration is


### PR DESCRIPTION
Noticed a spot where a now-necessary language specifier was missing. Also remove an extra line break.