### PR TITLE
Crossing Isolation Boundaries #7

### DIFF
--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -392,22 +392,6 @@ Here, a new type has been created that can satisfy the needed inheritance.
 Incorporating will be easiest if the conformance is only used internally by
 `WindowStyler`.
 
-> Link to "conformance proxy" code examples
-
-> Examples of diagnostics produced by the Swift 5.10 compiler for these issues include:  
->  
-> `Actor-isolated instance method '_' cannot be used to satisfy nonisolated protocol requirement`  
->  
-> `Main actor-isolated instance method '_' cannot be used to satisfy nonisolated protocol requirement`  
->  
-> `main actor-isolated property '_' cannot be used to satisfy nonisolated protocol requirement`  
->  
-> `actor-isolated property '_' cannot be used to satisfy nonisolated protocol requirement`  
->  
-> `main actor-isolated static property '_' cannot be used to satisfy nonisolated protocol requirement`  
->  
-> `main actor-isolated static method '_' cannot be used to satisfy nonisolated protocol requirement`  
-
 ## Crossing Isolation Boundaries
 
 Any value that needs to move from one isolation domain to another
@@ -469,8 +453,6 @@ Remember that `Sendable` is a guarantee of thread-safety, and part of a
 type's API contract.
 Removing the conformance is an API-breaking change.
 
-> Link to "making value types Sendable" code examples
-
 ### Preconcurrency Import
 
 Even if the type in another module is actually `Sendable`, it is not always
@@ -495,8 +477,6 @@ However, the compiler's behavior will be altered.
 When using the Swift 6 language mode, the produced here will be downgraded
 to a warning.
 The Swift 5 language mode will produce no diagnostics at all.
-
-> Link to "preconcurrency import" code examples
 
 ### Latent Isolation
 
@@ -540,8 +520,6 @@ removes the need for an asynchronous call.
 Fixing latent isolation issues can also potentially make further API
 simplification possible.
 
-> Link to "latent isolation" code examples
-
 Lack of `MainActor` isolation like this is, by far, the most common form of
 latent isolation.
 It is also very common for developers to hesitate to use this as a solution.
@@ -549,11 +527,6 @@ It is completely normal for programs with a user interface to have a large
 set of `MainActor`-isolated state.
 Concerns around long-running _synchronous_ work can often be addressed with
 just a handful of targeted `nonisolated` functions.
-
-> Note: To learn more about designing and controlling isolation,
-see [Isolation Granularity][]. (forthcoming)
-
-[Isolation Granularity]: #
 
 ### Computed Value
 
@@ -614,8 +587,6 @@ But further, data that is passed into or out of the actor may now itself
 need to cross the new isolation boundary.
 This can end up resulting in the need for yet more `Sendable` types.
 
-> Link to "actors" code examples
-
 #### Manual Synchronization
 
 If you have a type that is already doing manual synchronization, you can
@@ -636,8 +607,6 @@ As a general rule, if a type isn't already thread-safe, attempting to make
 it `Sendable` should not be your first approach.
 It is often much easier to try other techniques first, falling back to
 manual synchronization only when truly necessary.
-
-> Link to "manual synchronization" code examples
 
 #### Sendable Reference Types
 
@@ -664,8 +633,6 @@ final class Style: Sendable {
 Sometimes, this is a sign of a struct in disguise.
 But this can still be a useful technique when reference semantics need to be
 preserved, or for types that are part of a mixed Swift/Objective-C code base.
-
-> Link to "reference types" code examples
 
 ### Non-Isolated Initialization
 

--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -455,7 +455,7 @@ will result in an error:
 10 | 
 ```
 A very straightforward solution is just to make the type's `Sendable`
-conformance explict.
+conformance explicit.
 
 ```swift
 public struct ColorComponents: Sendable {
@@ -467,14 +467,14 @@ Even when trivial, adding a `Sendable` conformance should always be
 done with care.
 Remember that `Sendable` is a guarantee of thread-safety, and part of a
 type's API contract.
-Removing the conformance is a API-breaking change.
+Removing the conformance is an API-breaking change.
 
 > Link to "making value types Sendable" code examples
 
 ### Preconcurrency Import
 
 Even if the type in another module is actually `Sendable`, it is not always
-possible or convenient to modify its definition.
+possible to modify its definition.
 It also could be that the type is not `Sendable`, but depends on client
 cooperation for safe usage.
 In these cases, you can use a `@preconcurrency import` to address errors.
@@ -500,7 +500,7 @@ The Swift 5 language mode will produce no diagnostics at all.
 
 ### Latent Isolation
 
-Sometimes the _appearent_ need for a `Sendable` type can actually be the
+Sometimes the _apparent_ need for a `Sendable` type can actually be the
 symptom of a more fundamental isolation problem.
 The only reason a type needs to be `Sendable` is to cross isolation boundaries.
 If you can avoid crossing boundaries altogether, the result can
@@ -544,7 +544,7 @@ simplification possible.
 
 Lack of `MainActor` isolation like this is, by far, the most common form of
 latent isolation.
-It is also very common for developers to hestitate to use this as a solution.
+It is also very common for developers to hesitate to use this as a solution.
 It is completely normal for programs with a user interface to have a large
 set of `MainActor`-isolated state.
 Concerns around long-running _synchronous_ work can often be addressed with
@@ -572,8 +572,8 @@ sendability is side-stepped entirely.
 
 ### Sendable Conformance
 
-When encountering problem related to a lack of sendability, a very natural
-reaction is to just try to add a conformance to `Sendable`.
+When encountering problems related to crossing isolation domains, a very
+natural reaction is to just try to add a conformance to `Sendable`.
 You can make a type `Sendable` in four ways.
 
 #### Global Isolation
@@ -717,8 +717,8 @@ class WindowStyler {
 
 By making the `init` method `nonisolated`, it is free to be called from any
 isolation domain.
-This remains safe as the compile still guarantees that any state that *is*
-isolated will only be accessable from the `MainActor`.
+This remains safe as the compiler still guarantees that any state that *is*
+isolated will only be accessible from the `MainActor`.
 
 Most types like this will have isolated properties.
 But, this technique can still potentially be used, if the 

--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -555,6 +555,21 @@ see [Isolation Granularity][]. (forthcoming)
 
 [Isolation Granularity]: #
 
+### Computed Value
+
+Instead of trying to pass a non-`Sendable` type across a boundary, it may be
+possible to use a `Sendable` function that creates the needed values.
+
+```swift
+func updateStyle(backgroundColorProvider: @Sendable () -> ColorComponents) async {
+    await applyBackground(using: backgroundColorProvider)
+}
+```
+
+Here, it does not matter than `ColorComponents` is not `Sendable`.
+By using `@Sendable` function that can compute the value, the lack of
+sendability is side-stepped entirely.
+
 ### Sendable Conformance
 
 When encountering problem related to a lack of sendability, a very natural

--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -558,7 +558,7 @@ public struct ColorComponents {
 }
 ```
 
-By isolating this type to the `MainActor`, any accesses for other domains
+By isolating this type to the `MainActor`, any accesses from other isolation domains
 must be done asynchronously.
 This makes it possible to safely pass instances around across domains.
 

--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -406,17 +406,15 @@ changed.
 
 Many value types consist entirely of `Sendable` properties.
 The compiler will treat types like this as implicitly `Sendable`, but _only_
-within their defining module.
+when they are non-public.
 
 ```swift
-// module A
 public struct ColorComponents {
     public let red: Float
     public let green: Float
     public let blue: Float
 }
 
-// module B
 @MainActor
 func applyBackground(_ color: ColorComponents) {
 }
@@ -426,8 +424,8 @@ func updateStyle(backgroundColor: ColorComponents) async {
 }
 ```
 
-Despite `ColorComponents` being implicitly `Sendable`, this extra-module usage
-will result in an error:
+Despite `ColorComponents` being eligible for an implicit `Sendable`
+conformance, this code will result in the following error:
 
 ```
  6 | 

--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -297,7 +297,7 @@ Together, these could require significant structural changes to address.
 This may still be the right solution, but the side-effects should be carefully
 considered first, even if only a small number of types are involved.
 
-#### Using Preconcurrency
+#### Preconcurrency Conformance
 
 Swift has a number of mechanisms to help you adopt concurrency incrementally
 and interoperate with code that has not yet begun using concurrency at all.
@@ -470,6 +470,33 @@ type's API contract.
 Removing the conformance is a API-breaking change.
 
 > Link to "making value types Sendable" code examples
+
+### Preconcurrency Import
+
+Even if the type in another module is actually `Sendable`, it is not always
+possible or convenient to modify its definition.
+It also could be that the type is not `Sendable`, but depends on client
+cooperation for safe usage.
+In these cases, you can use a `@preconcurrency import` to address errors.
+
+```swift
+// ColorComponents defined here
+@preconcurrency import UnmigratedModule
+
+func updateStyle(backgroundColor: ColorComponents) async {
+    // crossing an isolation domain here
+    await applyBackground(backgroundColor)
+}
+```
+
+With the addition of this `@preconcurrency import`,
+`ColorComponents` remains non-`Sendable`.
+However, the compiler's behavior will be altered.
+When using the Swift 6 language mode, the produced here will be downgraded
+to a warning.
+The Swift 5 language mode will produce no diagnostics at all.
+
+> Link to "preconcurrency import" code examples
 
 ### Latent Isolation
 

--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -391,3 +391,236 @@ struct CustomWindowStyle: Styler {
 Here, a new type has been created that can satisfy the needed inheritance.
 Incorporating will be easiest if the conformance is only used internally by
 `WindowStyler`.
+
+> Link to "conformance proxy" code examples
+
+> Examples of diagnostics produced by the Swift 5.10 compiler for these issues include:  
+>  
+> `Actor-isolated instance method '_' cannot be used to satisfy nonisolated protocol requirement`  
+>  
+> `Main actor-isolated instance method '_' cannot be used to satisfy nonisolated protocol requirement`  
+>  
+> `main actor-isolated property '_' cannot be used to satisfy nonisolated protocol requirement`  
+>  
+> `actor-isolated property '_' cannot be used to satisfy nonisolated protocol requirement`  
+>  
+> `main actor-isolated static property '_' cannot be used to satisfy nonisolated protocol requirement`  
+>  
+> `main actor-isolated static method '_' cannot be used to satisfy nonisolated protocol requirement`  
+
+## Crossing Isolation Boundaries
+
+Any value that needs to move from one isolation domain to another
+must be `Sendable`.
+Using non-`Sendable` values in contexts that require `Sendable` types is a very
+common problem.
+And because libraries and frameworks may be updated to use Swift's
+concurrency features, these issues can come up even when your code hasn't
+changed.
+
+### Implicitly-Sendable Types
+
+Many value types consist entirely of `Sendable` properties.
+The compiler will treat types like this as implicitly `Sendable`, but _only_
+within their defining module.
+
+```swift
+// module A
+public struct ColorComponents {
+    public let red: Float
+    public let green: Float
+    public let blue: Float
+}
+
+// module B
+@MainActor
+func applyBackground(_ color: ColorComponents) {
+}
+
+func updateStyle(backgroundColor: ColorComponents) async {
+    await applyBackground(backgroundColor)
+}
+```
+
+Despite `ColorComponents` being implicitly `Sendable`, this extra-module usage
+will result in an error:
+
+```
+ 6 | 
+ 7 | func updateStyle(backgroundColor: ColorComponents) async {
+ 8 |     await applyBackground(backgroundColor)
+   |           |- error: sending 'backgroundColor' risks causing data races
+   |           `- note: sending task-isolated 'backgroundColor' to main actor-isolated global function 'applyBackground' risks causing data races between main actor-isolated and task-isolated uses
+ 9 | }
+10 | 
+```
+A very straightforward solution is just to make the type's `Sendable`
+conformance explict.
+
+```swift
+public struct ColorComponents: Sendable {
+    // ...
+}
+```
+
+Even when trivial, adding a `Sendable` conformance should always be
+done with care.
+Remember that `Sendable` is a guarantee of thread-safety, and part of a
+type's API contract.
+Removing the conformance is a API-breaking change.
+
+> Link to "making value types Sendable" code examples
+
+### Latent Isolation
+
+Sometimes the _appearent_ need for a `Sendable` type can actually be the
+symptom of a more fundamental isolation problem.
+The only reason a type needs to be `Sendable` is to cross isolation boundaries.
+If you can avoid crossing boundaries altogether, the result can
+often be both simpler and a better reflection of the true nature of your
+system.
+
+```swift
+@MainActor
+func applyBackground(_ color: ColorComponents) {
+}
+
+func updateStyle(backgroundColor: ColorComponents) async {
+    await applyBackground(backgroundColor)
+}
+```
+
+The `updateStyle(backgroundColor:)` function is non-isolated.
+This means that its non-`Sendable` parameter is also non-isolated.
+But, it is immediately crossing from this non-isolated domain to the
+`MainActor` when `applyBackground(_:)` is called.
+
+Since `updateStyle(backgroundColor:)` is working directly with
+`MainActor`-isolated functions and non-`Sendable` types,
+just applying `MainActor` isolation may be more appropriate.
+
+```swift
+@MainActor
+func updateStyle(backgroundColor: ColorComponents) async {
+    applyBackground(backgroundColor)
+}
+```
+
+Now, there is no longer an isolation boundary for the non-`Sendable` type to
+cross.
+And in this case, not only does this resolve the problem, it also
+removes the need for an asynchronous call.
+Fixing latent isolation issues can also potentially make further API
+simplification possible.
+
+> Link to "latent isolation" code examples
+
+Lack of `MainActor` isolation like this is, by far, the most common form of
+latent isolation.
+It is also very common for developers to hestitate to use this as a solution.
+It is completely normal for programs with a user interface to have a large
+set of `MainActor`-isolated state.
+Concerns around long-running _synchronous_ work can often be addressed with
+just a handful of targeted `nonisolated` functions.
+
+> Note: To learn more about designing and controlling isolation,
+see [Isolation Granularity][]. (forthcoming)
+
+[Isolation Granularity]: #
+
+### Sendable Conformance
+
+When encountering problem related to a lack of sendability, a very natural
+reaction is to just try to add a conformance to `Sendable`.
+You can make a type `Sendable` in four ways.
+
+#### Global Isolation
+
+Adding global isolation to any type will make it implicitly `Sendable`.
+
+```swift
+@MainActor
+public struct ColorComponents {
+    // ...
+}
+```
+
+By isolating this type to the `MainActor`, any accesses for other domains
+must be done asynchronously.
+This makes it possible to safely pass instances around across domains.
+
+#### Actors
+
+A reference type can be made `Sendable` by changing it from a `class`
+to an `actor`.
+
+```swift
+actor Style {
+    private var background: ColorComponents
+}
+```
+
+In addition to gaining a `Sendable` conformance, actors have their own
+isolation domain.
+This allows them to freely work with other non-`Sendable` types internally.
+This can be a major advantage, but does come with trade-offs.
+
+Because an actor's isolated methods all must be asynchronous,
+sites that access the type may now require an async context.
+This alone is a reason to make such a change with care.
+But further, data that is passed into or out of the actor may now itself
+need to cross the new isolation boundary.
+This can end up resulting in the need for yet more `Sendable` types.
+
+> Link to "actors" code examples
+
+#### Manual Synchronization
+
+If you have a type that is already doing manual synchronization, you can
+express this to the compiler by marking your `Sendable` conformance as
+`unchecked`.
+
+```swift
+class Style: @unchecked Sendable {
+    private var background: ColorComponents
+    private let queue: DispatchQueue
+}
+```
+
+You should not feel compelled to remove use of queues, locks, or other
+forms of manual synchronization to integrate with Swift's concurrency system.
+However, most types are not inherently thread-safe.
+As a general rule, if a type isn't already thread-safe, attempting to make
+it `Sendable` should not be your first approach.
+It is often much easier to try other techniques first, falling back to
+manual synchronization only when truly necessary.
+
+> Link to "manual synchronization" code examples
+
+#### Sendable Reference Types
+
+It is possible for reference types to be validated as `Sendable` without
+the `unchecked` qualifier.
+But, this can only be done under very narrow circumstances.
+
+To allow a checked `Sendable` conformance a class:
+
+- Must be `final`
+- Cannot inherit from another class other than `NSObject`
+- Cannot have any mutable properties
+
+```swift
+public struct ColorComponents: Sendable {
+    // ...
+}
+
+final class Style: Sendable {
+    private let background: ColorComponents
+}
+```
+
+Sometimes, this is a sign of a struct in disguise.
+But this can still be a useful technique when reference semantics need to be
+preserved, or for types that are part of a mixed Swift/Objective-C code base.
+
+> Link to "reference types" code examples

--- a/Guide.docc/DataRaceSafety.md
+++ b/Guide.docc/DataRaceSafety.md
@@ -395,6 +395,14 @@ isolation boundary.
 
 Values are only ever permitted to cross an isolation boundary where there
 is no potential for concurrent access to shared mutable state.
+Values can cross a boundary directly, via asychronous function calls.
+They can also cross boundaries indirectly when captured by closures.
+
+When you call an asynchronous function with a _different_ isolation domain,
+the parameters and return value need to cross a boundary.
+Closures introduce many opportunities to cross isolation boundaries.
+They can be created in one domain and then executed in another.
+They can even be executed in multiple, different domains.
 
 ### Sendable Types
 

--- a/Sources/MigrationInProgressModule/MigrationInProgressModule.swift
+++ b/Sources/MigrationInProgressModule/MigrationInProgressModule.swift
@@ -1,7 +1,9 @@
 import FullyMigratedModule
 
-func captureNonSendable(argument: ColorComponents) {
-    Task {
-        print(argument)
-    }
+@MainActor
+func applyBackground(_ color: ColorComponents) {
+}
+
+func updateStyle(backgroundColor: ColorComponents) async {
+    await applyBackground(backgroundColor)
 }

--- a/Sources/MigrationInProgressModule/MigrationInProgressModule.swift
+++ b/Sources/MigrationInProgressModule/MigrationInProgressModule.swift
@@ -1,9 +1,7 @@
 import FullyMigratedModule
 
-@MainActor
-func applyBackground(_ color: ColorComponents) {
-}
-
-func updateStyle(backgroundColor: ColorComponents) async {
-    await applyBackground(backgroundColor)
+func captureNonSendable(argument: ColorComponents) {
+    Task {
+        print(argument)
+    }
 }


### PR DESCRIPTION
This includes content that covers:

- Understanding when non-`Sendable` types can become a problem
- Ways to add a `Sendable` conformance
- Ways to avoid needing a `Sendable` conformance

It does not include preconcurrency or any other incremental migration. I think that preconcurrency is a big enough topic that it deserves a whole section to itself, even if it does end up referencing Sendable a lot.

Update:

I began working on a preconcurrency section, and I found it extremely difficult to integrate in a way that made sense. So I've integrated some of that content back into this PR.