### PR TITLE
Link to dynamic isolation section #37

### DIFF
--- a/Guide.docc/DataRaceSafety.md
+++ b/Guide.docc/DataRaceSafety.md
@@ -54,6 +54,9 @@ to express isolation requirements dynamically.
 Data isolation, be it static or dynamic, allows the
 compiler to guarantee Swift code you write is free of data races.
 
+> Note: For more information about using dynamic isolation,
+see <doc:IncrementalAdoption#Dynamic-Isolation>
+
 ### Isolation Domains
 
 Data isolation is the _mechanism_ used to protect shared mutable state.


### PR DESCRIPTION
Adds a link in the Data Race Safety article to point to dynamic isolation. Addresses #37.