### PR TITLE
Simplify and clarify async requirement usage

### DIFF
--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -278,11 +278,8 @@ protocol requirement with an isolated method:
 ```swift
 @MainActor
 class WindowStyler: Styler {
-    var showShadows: Bool = true
+    // matches, even though it is synchronous and actor-isolated
     func applyStyle() {
-        // implicit switch to the @MainActor before accessing main actor state
-
-        showShadows.toggle()
     }
 }
 ```


### PR DESCRIPTION
Originally, this was using a property to try to illustrate the isolation, but I think a little inline comment is way clearer.

Addresses #36

(depends on #33)

