### PR TITLE
Mattmassicotte/nonisolated deinit

### DIFF
--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -702,3 +702,65 @@ class WindowStyler {
     }
 }
 ```
+
+### Non-Isolated Deinitialization
+
+By default, any custom initializers you write will have the same isolation as
+their enclosing scope.
+This is _not_ the case for deinitializers, which are always non-isolated.
+
+```swift
+@MainActor
+class WindowStyler {
+    // A MainActor-isolated type
+    private let store = StyleStore()
+
+    init {
+        // infers MainActor
+    }
+
+    deinit {
+        store.stopNotifications()
+    }
+}
+```
+
+This code produces the error:
+
+```
+error: call to main actor-isolated instance method 'stopNotifications()' in a synchronous nonisolated context
+ 5 |     
+ 6 |     deinit {
+ 7 |         store.stopNotifications()
+   |               `- error: call to main actor-isolated instance method 'stopNotifications()' in a synchronous nonisolated context
+ 8 |     }
+ 9 | }
+```
+
+While this might feel surprising, given that this type is `MainActor`-isolated,
+this is not a new constraint.
+The thread that executes a deinitializer has never been guaranteed and
+Swift's data isolation is now just surfacing that fact.
+
+Often, the work being done within the `deinit` does not need to be synchronous.
+A solution is to use an unstructured `Task` to first capture and
+then operate on the isolated values.
+When using this technique,
+it is _critical_ to ensure you do not capture `self`, even implicitly.
+
+```swift
+@MainActor
+class WindowStyler {
+    // A MainActor-isolated type
+    private let store = StyleStore()
+    
+    deinit {
+        Task { [store] in
+            await store.stopNotifications()
+        }
+    }
+}
+```
+
+> Important: **Never** extend the life-time of `self` from within
+`deinit`. Doing so will crash at runtime.

--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -457,7 +457,7 @@ will result in an error:
 10 | 
 ```
 A very straightforward solution is just to make the type's `Sendable`
-conformance explict.
+conformance explicit.
 
 ```swift
 public struct ColorComponents: Sendable {
@@ -469,14 +469,14 @@ Even when trivial, adding a `Sendable` conformance should always be
 done with care.
 Remember that `Sendable` is a guarantee of thread-safety, and part of a
 type's API contract.
-Removing the conformance is a API-breaking change.
+Removing the conformance is an API-breaking change.
 
 > Link to "making value types Sendable" code examples
 
 ### Preconcurrency Import
 
 Even if the type in another module is actually `Sendable`, it is not always
-possible or convenient to modify its definition.
+possible to modify its definition.
 It also could be that the type is not `Sendable`, but depends on client
 cooperation for safe usage.
 In these cases, you can use a `@preconcurrency import` to address errors.
@@ -502,7 +502,7 @@ The Swift 5 language mode will produce no diagnostics at all.
 
 ### Latent Isolation
 
-Sometimes the _appearent_ need for a `Sendable` type can actually be the
+Sometimes the _apparent_ need for a `Sendable` type can actually be the
 symptom of a more fundamental isolation problem.
 The only reason a type needs to be `Sendable` is to cross isolation boundaries.
 If you can avoid crossing boundaries altogether, the result can
@@ -546,7 +546,7 @@ simplification possible.
 
 Lack of `MainActor` isolation like this is, by far, the most common form of
 latent isolation.
-It is also very common for developers to hestitate to use this as a solution.
+It is also very common for developers to hesitate to use this as a solution.
 It is completely normal for programs with a user interface to have a large
 set of `MainActor`-isolated state.
 Concerns around long-running _synchronous_ work can often be addressed with
@@ -574,8 +574,8 @@ sendability is side-stepped entirely.
 
 ### Sendable Conformance
 
-When encountering problem related to a lack of sendability, a very natural
-reaction is to just try to add a conformance to `Sendable`.
+When encountering problems related to crossing isolation domains, a very
+natural reaction is to just try to add a conformance to `Sendable`.
 You can make a type `Sendable` in four ways.
 
 #### Global Isolation
@@ -719,8 +719,8 @@ class WindowStyler {
 
 By making the `init` method `nonisolated`, it is free to be called from any
 isolation domain.
-This remains safe as the compile still guarantees that any state that *is*
-isolated will only be accessable from the `MainActor`.
+This remains safe as the compiler still guarantees that any state that *is*
+isolated will only be accessible from the `MainActor`.
 
 Most types like this will have isolated properties.
 But, this technique can still potentially be used, if the 

--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -408,17 +408,15 @@ changed.
 
 Many value types consist entirely of `Sendable` properties.
 The compiler will treat types like this as implicitly `Sendable`, but _only_
-within their defining module.
+when they are non-public.
 
 ```swift
-// module A
 public struct ColorComponents {
     public let red: Float
     public let green: Float
     public let blue: Float
 }
 
-// module B
 @MainActor
 func applyBackground(_ color: ColorComponents) {
 }
@@ -428,8 +426,8 @@ func updateStyle(backgroundColor: ColorComponents) async {
 }
 ```
 
-Despite `ColorComponents` being implicitly `Sendable`, this extra-module usage
-will result in an error:
+Despite `ColorComponents` being eligible for an implicit `Sendable`
+conformance, this code will result in the following error:
 
 ```
  6 | 

--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -394,22 +394,6 @@ Here, a new type has been created that can satisfy the needed inheritance.
 Incorporating will be easiest if the conformance is only used internally by
 `Island`.
 
-> Link to "conformance proxy" code examples
-
-> Examples of diagnostics produced by the Swift 5.10 compiler for these issues include:  
->  
-> `Actor-isolated instance method '_' cannot be used to satisfy nonisolated protocol requirement`  
->  
-> `Main actor-isolated instance method '_' cannot be used to satisfy nonisolated protocol requirement`  
->  
-> `main actor-isolated property '_' cannot be used to satisfy nonisolated protocol requirement`  
->  
-> `actor-isolated property '_' cannot be used to satisfy nonisolated protocol requirement`  
->  
-> `main actor-isolated static property '_' cannot be used to satisfy nonisolated protocol requirement`  
->  
-> `main actor-isolated static method '_' cannot be used to satisfy nonisolated protocol requirement`  
-
 ## Crossing Isolation Boundaries
 
 Any value that needs to move from one isolation domain to another
@@ -471,8 +455,6 @@ Remember that `Sendable` is a guarantee of thread-safety, and part of a
 type's API contract.
 Removing the conformance is an API-breaking change.
 
-> Link to "making value types Sendable" code examples
-
 ### Preconcurrency Import
 
 Even if the type in another module is actually `Sendable`, it is not always
@@ -497,8 +479,6 @@ However, the compiler's behavior will be altered.
 When using the Swift 6 language mode, the produced here will be downgraded
 to a warning.
 The Swift 5 language mode will produce no diagnostics at all.
-
-> Link to "preconcurrency import" code examples
 
 ### Latent Isolation
 
@@ -542,8 +522,6 @@ removes the need for an asynchronous call.
 Fixing latent isolation issues can also potentially make further API
 simplification possible.
 
-> Link to "latent isolation" code examples
-
 Lack of `MainActor` isolation like this is, by far, the most common form of
 latent isolation.
 It is also very common for developers to hesitate to use this as a solution.
@@ -551,11 +529,6 @@ It is completely normal for programs with a user interface to have a large
 set of `MainActor`-isolated state.
 Concerns around long-running _synchronous_ work can often be addressed with
 just a handful of targeted `nonisolated` functions.
-
-> Note: To learn more about designing and controlling isolation,
-see [Isolation Granularity][]. (forthcoming)
-
-[Isolation Granularity]: #
 
 ### Computed Value
 
@@ -616,8 +589,6 @@ But further, data that is passed into or out of the actor may now itself
 need to cross the new isolation boundary.
 This can end up resulting in the need for yet more `Sendable` types.
 
-> Link to "actors" code examples
-
 #### Manual Synchronization
 
 If you have a type that is already doing manual synchronization, you can
@@ -638,8 +609,6 @@ As a general rule, if a type isn't already thread-safe, attempting to make
 it `Sendable` should not be your first approach.
 It is often much easier to try other techniques first, falling back to
 manual synchronization only when truly necessary.
-
-> Link to "manual synchronization" code examples
 
 #### Sendable Reference Types
 
@@ -666,8 +635,6 @@ final class Style: Sendable {
 Sometimes, this is a sign of a struct in disguise.
 But this can still be a useful technique when reference semantics need to be
 preserved, or for types that are part of a mixed Swift/Objective-C code base.
-
-> Link to "reference types" code examples
 
 ### Non-Isolated Initialization
 

--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -300,7 +300,7 @@ Together, these could require significant structural changes to address.
 This may still be the right solution, but the side-effects should be carefully
 considered first, even if only a small number of types are involved.
 
-#### Using Preconcurrency
+#### Preconcurrency Conformance
 
 Swift has a number of mechanisms to help you adopt concurrency incrementally
 and interoperate with code that has not yet begun using concurrency at all.
@@ -472,6 +472,33 @@ type's API contract.
 Removing the conformance is a API-breaking change.
 
 > Link to "making value types Sendable" code examples
+
+### Preconcurrency Import
+
+Even if the type in another module is actually `Sendable`, it is not always
+possible or convenient to modify its definition.
+It also could be that the type is not `Sendable`, but depends on client
+cooperation for safe usage.
+In these cases, you can use a `@preconcurrency import` to address errors.
+
+```swift
+// ColorComponents defined here
+@preconcurrency import UnmigratedModule
+
+func updateStyle(backgroundColor: ColorComponents) async {
+    // crossing an isolation domain here
+    await applyBackground(backgroundColor)
+}
+```
+
+With the addition of this `@preconcurrency import`,
+`ColorComponents` remains non-`Sendable`.
+However, the compiler's behavior will be altered.
+When using the Swift 6 language mode, the produced here will be downgraded
+to a warning.
+The Swift 5 language mode will produce no diagnostics at all.
+
+> Link to "preconcurrency import" code examples
 
 ### Latent Isolation
 

--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -653,3 +653,72 @@ But this can still be a useful technique when reference semantics need to be
 preserved, or for types that are part of a mixed Swift/Objective-C code base.
 
 > Link to "reference types" code examples
+
+### Non-Isolated Initialization
+
+Actor-isolated types can present a problem when they have to be initialized in
+a non-isolated context.
+This occurs frequently when the type is used in a default value expression or
+as a property initializer.
+
+> Note: These problems could also be a symptom of
+[latent isolation](#Latent-Isolation) or an
+[under-specified protocol](#Under-Specified-Protocol).
+
+Here the non-isolated `Stylers` type is making a call to a
+`MainActor`-isolated initializer.
+
+```swift
+@MainActor
+class WindowStyler {
+    init() {
+    }
+}
+
+struct Stylers {
+    static let window = WindowStyler()
+}
+```
+
+This code results in the following error:
+
+```
+ 7 | 
+ 8 | struct Stylers {
+ 9 |     static let window = WindowStyler()
+   |                `- error: main actor-isolated default value in a nonisolated context
+10 | }
+11 | 
+```
+
+Globally-isolated types sometimes don't actually need to reference any global
+actor state in their initializers.
+
+```swift
+@MainActor
+class WindowStyler {
+    nonisolated init() {
+    }
+}
+```
+
+By making the `init` method `nonisolated`, it is free to be called from any
+isolation domain.
+This remains safe as the compile still guarantees that any state that *is*
+isolated will only be accessable from the `MainActor`.
+
+Most types like this will have isolated properties.
+But, this technique can still potentially be used, if the 
+properties themselves can be initialized using default expressions.
+
+```swift
+@MainActor
+class WindowStyler {
+    // also MainActor-isolated
+    private var windowCount = 1
+
+    nonisolated init() {
+        // type is still fully-initialized here
+    }
+}
+```

--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -557,6 +557,21 @@ see [Isolation Granularity][]. (forthcoming)
 
 [Isolation Granularity]: #
 
+### Computed Value
+
+Instead of trying to pass a non-`Sendable` type across a boundary, it may be
+possible to use a `Sendable` function that creates the needed values.
+
+```swift
+func updateStyle(backgroundColorProvider: @Sendable () -> ColorComponents) async {
+    await applyBackground(using: backgroundColorProvider)
+}
+```
+
+Here, it does not matter than `ColorComponents` is not `Sendable`.
+By using `@Sendable` function that can compute the value, the lack of
+sendability is side-stepped entirely.
+
 ### Sendable Conformance
 
 When encountering problem related to a lack of sendability, a very natural

--- a/Guide.docc/DataRaceSafety.md
+++ b/Guide.docc/DataRaceSafety.md
@@ -395,6 +395,14 @@ isolation boundary.
 
 Values are only ever permitted to cross an isolation boundary where there
 is no potential for concurrent access to shared mutable state.
+Values can cross a boundary directly, via asychronous function calls.
+They can also cross boundaries indirectly when captured by closures.
+
+When you call an asynchronous function with a _different_ isolation domain,
+the parameters and return value need to cross a boundary.
+Closures introduce many opportunities to cross isolation boundaries.
+They can be created in one domain and then executed in another.
+They can even be executed in multiple, different domains.
 
 ### Sendable Types
 

--- a/Sources/MigrationInProgressModule/MigrationInProgressModule.swift
+++ b/Sources/MigrationInProgressModule/MigrationInProgressModule.swift
@@ -1,7 +1,9 @@
 import FullyMigratedModule
 
-func captureNonSendable(argument: ColorComponents) {
-    Task {
-        print(argument)
-    }
+@MainActor
+func applyBackground(_ color: ColorComponents) {
+}
+
+func updateStyle(backgroundColor: ColorComponents) async {
+    await applyBackground(backgroundColor)
 }

--- a/Sources/MigrationInProgressModule/MigrationInProgressModule.swift
+++ b/Sources/MigrationInProgressModule/MigrationInProgressModule.swift
@@ -1,9 +1,7 @@
 import FullyMigratedModule
 
-@MainActor
-func applyBackground(_ color: ColorComponents) {
-}
-
-func updateStyle(backgroundColor: ColorComponents) async {
-    await applyBackground(backgroundColor)
+func captureNonSendable(argument: ColorComponents) {
+    Task {
+        print(argument)
+    }
 }


### PR DESCRIPTION
An example of how to deal with synchronous deinit errors. Addresses #30.

This PR may conflict with #31, but should be trivial to fix up, regardless of which gets merged first.