### PR TITLE
Explain how to opt-out with Swift 6 tools

### DIFF
--- a/Guide.docc/Swift6Mode.md
+++ b/Guide.docc/Swift6Mode.md
@@ -27,12 +27,13 @@ invocation using the `-Xswiftc` flag:
 
 A `Package.swift` file that uses `swift-tools-version` of `6.0` will enable
 the Swift 6 language mode for all targets.
-With that tools version, you can still change the language mode for the package
-as a whole:
+You can still set the language mode for the package as a whole using the 
+`swiftLanguageVersions` property of `Package`.
+However, you can now also change the language mode as needed on a
+per-target basis using the new `swiftLanguageVersion` build setting:
 
 ```swift
 // swift-tools-version: 6.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 let package = Package(
     name: "MyPackage",
@@ -40,19 +41,17 @@ let package = Package(
         // ...
     ],
     targets: [
-        // ...
-    ],
-    swiftLanguageVersions: [.v5]
-)
-```
-
-You can also change the language mode on a per-target basis:
-
-```swift
-.target(
-    name: "MyTarget",
-    swiftSettings: [
-        .swiftLanguageVersion(.v5)
+        // Uses the default tools language mode
+        .target(
+            name: "FullyMigrated",
+        ),
+        // Still requires 5
+        .target(
+            name: "NotQuiteReadyYet",
+            swiftSettings: [
+                .swiftLanguageVersion(.v5)
+            ]
+        )
     ]
 )
 ```

--- a/Guide.docc/Swift6Mode.md
+++ b/Guide.docc/Swift6Mode.md
@@ -25,32 +25,35 @@ invocation using the `-Xswiftc` flag:
 
 ### Package manifest
 
-To change the language mode for package as a whole:
+A `Package.swift` file that uses `swift-tools-version` of `6.0` will enable
+the Swift 6 language mode for all targets.
+With that tools version, you can still change the language mode for the package
+as a whole:
 
 ```swift
-// swift-tools-version:6.0
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 let package = Package(
-  name: "MyPackage",
-  products: [
-    // ...
-  ],
-  targets: [
-    // ...
-  ],
-  swiftLanguageVersions: [.v6]
+    name: "MyPackage",
+    products: [
+        // ...
+    ],
+    targets: [
+        // ...
+    ],
+    swiftLanguageVersions: [.v5]
 )
 ```
 
-To change the language mode on a per-target basis:
+You can also change the language mode on a per-target basis:
 
 ```swift
 .target(
-  name: "MyTarget",
-  swiftSettings: [
-    .swiftLanguageVersion(.v6)
-  ]
+    name: "MyTarget",
+    swiftSettings: [
+        .swiftLanguageVersion(.v5)
+    ]
 )
 ```
 

--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,5 @@ let package = Package(
             name: "Swift6Examples",
             dependencies: ["Library"]
         )
-    ],
-    swiftLanguageVersions: [.v6]
+    ]
 )


### PR DESCRIPTION
The article about how to enable Swift 6 doesn't really cover the correct behavior for SPM. It currently explains how to opt-in, but when using Swift tools 6.0, what you really need to understand is how to opt-out.

I also took the opportunity to take this advice myself and remove the redundant language mode in this project's `Package.swift`. 

https://github.com/apple/swift-migration-guide/issues/17

Thankfully @bnbarham was looking closely enough to catch this.