### PR TITLE
Add guidance about width limited task group

### DIFF
--- a/Guide.docc/IncrementalAdoption.md
+++ b/Guide.docc/IncrementalAdoption.md
@@ -264,7 +264,7 @@ Creating a task (in `addTask`) needs to allocate some memory for the task in ord
 while this amount of memory isn't too large, it can become significant if creating thousands of tasks which don't get to
 execute immediately but are just waiting until the executor gets to run them.
 
-When faced with such situation, it may be beneficial to manually throttle the number of concurrently added tasks to the task group, as follows:
+When faced with such a situation, it may be beneficial to manually throttle the number of concurrently added tasks to the task group, as follows:
 
 ```swift
 let lotsOfWork: [Work] = ... 

--- a/Guide.docc/IncrementalAdoption.md
+++ b/Guide.docc/IncrementalAdoption.md
@@ -229,7 +229,7 @@ NS_SWIFT_UNAVAILABLE_FROM_ASYNC(msg)
 ```
 ## Dispatch
 
-Some patterns which you may be used to from Dispatch or other concurrency libraries,
+Some patterns which you may be used to from Dispatch or other concurrency libraries
 may need to be re-shaped in order to fit the world of Swift's structured concurrency model. 
 
 ### Limiting concurrency using Task Groups

--- a/Guide.docc/IncrementalAdoption.md
+++ b/Guide.docc/IncrementalAdoption.md
@@ -227,3 +227,72 @@ NS_SWIFT_ASYNC_NAME
 NS_SWIFT_ASYNC_NOTHROW
 NS_SWIFT_UNAVAILABLE_FROM_ASYNC(msg)
 ```
+## Dispatch
+
+Some patterns which you may be used to from Dispatch or other concurrency libraries,
+may need to be re-shaped in order to fit the world of Swift's structured concurrency model. 
+
+### Limiting concurrency using Task Groups
+
+Sometimes you may find yourself with a large list of work to be processed.
+
+While it is possible to just enqueue "all" those work items to a task group like this:
+
+```swift
+// WARNING: Potentially wasteful -- perhaps this creates thousands of tasks concurrently (?!)
+
+let lotsOfWork: [Work] = ...
+await withTaskGroup(of: Something.self) { group in
+  for work in lotsOfWork {
+    // WARNING: If this is thousands of items, we may end up creating a lot of tasks
+    //  which won't get to be executed until much later, as we have a global limit on
+    //  the amount of concurrently running tasks - depending on the core count of the system,
+    //  and the default global executor's configuration.
+    group.addTask {
+      await work.work()
+    }
+  }
+
+  for await result in group {
+    process(result) // process the result somehow, depends on your needs
+  }
+}
+```
+
+If you suspect you may be dealing with hundreds or thousands of items, it may be wasteful to enqueue them all immediately.
+Creating a task (in `addTask`) needs to allocate some memory for the task in order to suspend and execute,
+while this amount of memory isn't too large, it can become significant if creating thousands of tasks which don't get to
+execute immediately but are just waiting until the executor gets to run them.
+
+When faced with such situation, it may be beneficial to manually throttle the number of concurrently added tasks to the task group, as follows:
+
+```swift
+let lotsOfWork: [Work] = ... 
+let maxConcurrentWorkTasks = min(lotsOfWork.count, 10)
+assert(maxConcurrentWorkTasks > 0)
+
+await withTaskGroup(of: Something.self) { group in
+    var submittedWork = 0
+    for _ in 0..<maxConcurrentWorkTasks {
+        group.addTask { // or 'addTaskUnlessCancelled'
+            await lotsOfWork[submittedWork].work() 
+        }
+        submittedWork += 1
+    }
+    
+    for await result in group {
+        process(result) // process the result somehow, depends on your needs
+    
+        // Every time we get a result back, check if there's more work we should submit and do so
+        if submittedWork < lotsOfWork.count, 
+           let remainingWorkItem = lotsOfWork[submittedWork] {
+            group.addTask { // or 'addTaskUnlessCancelled'
+                await remainingWorkItem.work() 
+            }  
+        }
+        submittedWork += 1
+    }
+}
+```
+
+Currently, there is no built-in operation that'd handle this for you, but it is something worth exploring in the future.

--- a/Guide.docc/IncrementalAdoption.md
+++ b/Guide.docc/IncrementalAdoption.md
@@ -289,8 +289,8 @@ await withTaskGroup(of: Something.self) { group in
             group.addTask { // or 'addTaskUnlessCancelled'
                 await remainingWorkItem.work() 
             }  
+            submittedWork += 1
         }
-        submittedWork += 1
     }
 }
 ```

--- a/Guide.docc/IncrementalAdoption.md
+++ b/Guide.docc/IncrementalAdoption.md
@@ -294,5 +294,3 @@ await withTaskGroup(of: Something.self) { group in
     }
 }
 ```
-
-Currently, there is no built-in operation that'd handle this for you, but it is something worth exploring in the future.

--- a/Guide.docc/MigrationGuide.md
+++ b/Guide.docc/MigrationGuide.md
@@ -47,3 +47,4 @@ Existing projects will not switch to this mode without configuration changes.
 - <doc:CompleteChecking>
 - <doc:IncrementalAdoption>
 - <doc:CommonProblems>
+- <doc:RuntimeBehavior>

--- a/Guide.docc/RuntimeBehavior.md
+++ b/Guide.docc/RuntimeBehavior.md
@@ -1,0 +1,71 @@
+# Runtime Behavior
+
+Learn how Swift concurrency runtime semantics differ from other runtimes you may
+be familiar with, and familiarize yourself with common patterns to achieve
+similar end results in terms of execution semantics.
+
+Swift's concurrency model with a strong focus on async/await, actors and tasks,
+means that some patterns from other libraries or concurrency runtimes don't
+translate directly into this new model. In this section, we'll explore common
+patterns and differences in runtime behavior to be aware of, and how to address
+them while you migrate your code to Swift concurrency.
+
+## Limiting concurrency using Task Groups
+
+Sometimes you may find yourself with a large list of work to be processed.
+
+While it is possible to just enqueue "all" those work items to a task group like this:
+
+```swift
+// Potentially wasteful -- perhaps this creates thousands of tasks concurrently (?!)
+
+let lotsOfWork: [Work] = ...
+await withTaskGroup(of: Something.self) { group in
+  for work in lotsOfWork {
+    // If this is thousands of items, we may end up creating a lot of tasks here.
+    group.addTask {
+      await work.work()
+    }
+  }
+
+  for await result in group {
+    process(result) // process the result somehow, depends on your needs
+  }
+}
+```
+
+If you suspect you may be dealing with hundreds or thousands of items, it may be wasteful to enqueue them all immediately.
+Creating a task (in `addTask`) needs to allocate some memory for the task in order to suspend and execute.
+This amount of memory isn't too large, it can become significant if creating thousands of tasks which don't get to
+execute immediately but are just waiting until the executor gets to run them.
+
+When faced with such a situation, it may be beneficial to manually throttle the number of concurrently added tasks to the task group, as follows:
+
+```swift
+let lotsOfWork: [Work] = ... 
+let maxConcurrentWorkTasks = min(lotsOfWork.count, 10)
+assert(maxConcurrentWorkTasks > 0)
+
+await withTaskGroup(of: Something.self) { group in
+    var submittedWork = 0
+    for _ in 0..<maxConcurrentWorkTasks {
+        group.addTask { // or 'addTaskUnlessCancelled'
+            await lotsOfWork[submittedWork].work() 
+        }
+        submittedWork += 1
+    }
+    
+    for await result in group {
+        process(result) // process the result somehow, depends on your needs
+    
+        // Every time we get a result back, check if there's more work we should submit and do so
+        if submittedWork < lotsOfWork.count, 
+           let remainingWorkItem = lotsOfWork[submittedWork] {
+            group.addTask { // or 'addTaskUnlessCancelled'
+                await remainingWorkItem.work() 
+            }  
+            submittedWork += 1
+        }
+    }
+}
+```


### PR DESCRIPTION
TaskGroup can technically support "tons of" work to be submitted into it, but this can be wasteful memory wise as those tasks will often just sit around doing nothing.

Show an example that is based on what we've shown before in wwdc talks like here:
https://developer.apple.com/videos/play/wwdc2023/10170/?time=687

That explains how to manually control the width of a task group.