### PR TITLE
Add WIP note and repo link

### DIFF
--- a/Guide.docc/MigrationGuide.md
+++ b/Guide.docc/MigrationGuide.md
@@ -47,6 +47,11 @@ and _language mode_.
 The Swift 6 compiler supports four distinct language modes: "6", "5", "4.2",
 and "4".
 
+> Note: This guide is under active development. You can view the source, see
+full code examples, and learn about how to contribute in the [repository][].
+
+[repository]: https://github.com/apple/swift-migration-guide
+
 ## Topics
 
 - <doc:DataRaceSafety>


### PR DESCRIPTION
I spent some time trying to find a nicer way to present this information, but DocC isn't completely free-form. The only content I can put under the `Topics` section is links to other content documents.

So I opted for a note. It isn't my favorite, stylistically. Could also be put within the content itself, maybe?

<img width="872" alt="Screenshot 2024-06-12 at 11 28 23 AM" src="https://github.com/apple/swift-migration-guide/assets/85322/e9fec00b-23c7-49e6-bdf0-65b0c36f1623">
