### PR TITLE
Really basic test targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,10 @@ let package = Package(
         .target(
             name: "Library"
         ),
+        .testTarget(
+            name: "LibraryXCTests",
+            dependencies: ["ObjCLibrary", "Library"]
+        ),
         .target(
             name: "ObjCLibrary",
             publicHeadersPath: "."

--- a/Sources/ObjCLibrary/JPKJetPack.h
+++ b/Sources/ObjCLibrary/JPKJetPack.h
@@ -1,0 +1,12 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface JPKJetPack : NSObject
+
+/// Disable async to show how completion handlers work explicitly.
++ (void)jetPackConfiguration:(void (NS_SWIFT_SENDABLE ^)(void))completionHandler NS_SWIFT_DISABLE_ASYNC;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/ObjCLibrary/JPKJetPack.m
+++ b/Sources/ObjCLibrary/JPKJetPack.m
@@ -1,0 +1,11 @@
+#import "JPKJetPack.h"
+
+@implementation JPKJetPack
+
++ (void)jetPackConfiguration:(void (^)(void))completionHandler {
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        completionHandler();
+    });
+}
+
+@end

--- a/Sources/ObjCLibrary/ObjCLibrary.h
+++ b/Sources/ObjCLibrary/ObjCLibrary.h
@@ -8,3 +8,5 @@ NS_SWIFT_UI_ACTOR
 @interface PCMPatternStore : NSObject
 
 @end
+
+#import "JPKJetPack.h"

--- a/Tests/Library/LibraryTests.swift
+++ b/Tests/Library/LibraryTests.swift
@@ -1,0 +1,24 @@
+import Library
+import ObjCLibrary
+import Testing
+
+struct LibraryTest {
+    @Test func testNonIsolated() throws {
+        let color = ColorComponents()
+
+        #expect(color.red == 1.0)
+    }
+
+    @MainActor
+    @Test func testIsolated() throws {
+        let color = GlobalActorIsolatedColorComponents()
+
+        #expect(color.red == 1.0)
+    }
+
+    @Test func testNonIsolatedWithGlobalActorIsolatedType() async throws {
+        let color = await GlobalActorIsolatedColorComponents()
+
+        await #expect(color.red == 1.0)
+    }
+}

--- a/Tests/Library/LibraryXCTests.swift
+++ b/Tests/Library/LibraryXCTests.swift
@@ -1,0 +1,37 @@
+import ObjCLibrary
+import Library
+import XCTest
+
+final class LibraryXCTests: XCTestCase {
+    func testNonIsolated() throws {
+        let color = ColorComponents()
+
+        XCTAssertEqual(color.red, 1.0)
+    }
+
+    @MainActor
+    func testIsolated() throws {
+        let color = GlobalActorIsolatedColorComponents()
+
+        XCTAssertEqual(color.red, 1.0)
+    }
+
+    func testNonIsolatedWithGlobalActorIsolatedType() async throws {
+        let color = await GlobalActorIsolatedColorComponents()
+        let redComponent = await color.red
+
+        XCTAssertEqual(redComponent, 1.0)
+    }
+}
+
+extension LibraryXCTests {
+    func testCallbackOperation() async {
+        let exp = expectation(description: "config callback")
+
+        JPKJetPack.jetPackConfiguration {
+            exp.fulfill()
+        }
+
+        await fulfillment(of: [exp])
+    }
+}


### PR DESCRIPTION
Put together a skeleton with some testing targets. There's relatively little going on in here. However, I did steal @ktoso's `JetPack` idea to help illustrate some Obj-C interop.