### PR TITLE
Handle missing sendable

### DIFF
--- a/Guide.docc/IncrementalAdoption.md
+++ b/Guide.docc/IncrementalAdoption.md
@@ -166,7 +166,7 @@ class PersonalTransportation {
     func configure() {
         // This function is missing a Sendable annotation
         JPKJetPack.jetPackConfiguration {
-            // MainActor isolation will be inferred here, incorrectly
+            // MainActor isolation will be inferred here
             self.applyConfiguration()
         }
     }


### PR DESCRIPTION
There's an open question in #63 about how exactly this should behave at runtime. I used the wording from the issue.

I also opted for the content from #66, honestly, just because its fun. But it does kind of no longer match the flow of the entire document quite as well, so this is something I can revisit.