### PR TITLE
MainActor.run content fix #57

### DIFF
--- a/Guide.docc/IncrementalAdoption.md
+++ b/Guide.docc/IncrementalAdoption.md
@@ -149,6 +149,33 @@ class UIStyler {
 Combining static and dynamic isolation can be a powerful tool to keep the
 scope of changes gradual.
 
+### Manual MainActor Isolation
+
+The `assumeIsolated` method is synchronous and exists to express isolation
+that would otherwise be invisible to the compiler.
+The `MainActor` type also has a method you can use to manually switch
+isolation in an asynchronous context.
+
+```swift
+// type that should be MainActor, but has not been updated yet
+class PersonalTransportation {
+}
+
+await MainActor.run {
+    // isolated to the MainActor here
+    let transport = PersonalTransportation()
+    
+    // ...
+}
+```
+
+Remember that static isolation allows the compiler to both verify and automate
+the process of switching isolation as needed.
+Even when used in combination with static isolation, it can be difficult
+to determine when `MainActor.run` is truly necessary.
+It can be useful during migration, but should not be used as a substitute
+for expressing the isolation requirements of your system statically.
+
 ## Missing Annotations
 
 Dynamic isolation gives you tools to express isolation at runtime.


### PR DESCRIPTION
The Incremental Adoption article has reasonable coverage of `assumeIsolated`, but lacks any mention of `MainActor.run`. I wanted to include this specifcally, because it is used a lot. I did my best to illustrate its utility while also highlighting its drawbacks.