### PR TITLE
Edits for style and purpose

### DIFF
--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -145,7 +145,7 @@ Here, we see two functions that could access the internal state of the
 The compiler only permits these kinds of cross-isolation accesses with
 `Sendable` types.
 One option is to isolate the variable to a single domain using a global actor.
-But it could also make sense to instead add a conformance to `Sendable`
+Alternatively, it might make sense to add a conformance to `Sendable`
 directly.
 
 ## Protocol Conformance Isolation Mismatch
@@ -432,9 +432,9 @@ func updateStyle(backgroundColor: ColorComponents) async {
 }
 ```
 
-`Sendable` conformance is part of a type's public API contract,
+A `Sendable` conformance is part of a type's public API contract,
 which is up to you to declare.
-Because `ColorComponents` is marked `public` it will not implicitly
+Because `ColorComponents` is marked `public`, it will not implicitly
 conform to `Sendable`.
 This will result in the following error:
 
@@ -508,7 +508,7 @@ func updateStyle(backgroundColor: ColorComponents) async {
 
 The `updateStyle(backgroundColor:)` function is non-isolated.
 This means that its non-`Sendable` parameter is also non-isolated.
-But it crosses immediately from this non-isolated domain to the
+The implementation crosses immediately from this non-isolated domain to the
 `MainActor` when `applyBackground(_:)` is called.
 
 Since `updateStyle(backgroundColor:)` is working directly with
@@ -584,7 +584,7 @@ actor Style {
 }
 ```
 
-In addition to gaining `Sendable` conformance, actors receive their own
+In addition to gaining a `Sendable` conformance, actors receive their own
 isolation domain.
 This allows them to work freely with other non-`Sendable` types internally.
 This can be a major advantage, but does come with trade-offs.
@@ -622,7 +622,7 @@ manual synchronization only when truly necessary.
 It is possible for reference types to be validated as `Sendable` without
 the `unchecked` qualifier, but this is only done under very narrow circumstances.
 
-To allow checked `Sendable` conformance, a class:
+To allow a checked `Sendable` conformance, a class:
 
 - Must be `final`
 - Cannot inherit from another class other than `NSObject`

--- a/Guide.docc/DataRaceSafety.md
+++ b/Guide.docc/DataRaceSafety.md
@@ -245,7 +245,7 @@ automatically based on context.
 Task isolation, just like all other Swift code, determines what mutable state
 they can access.
 
-Tasks can run both synchronous and asynchronous code. But regardless of the
+Tasks can run both synchronous and asynchronous code. Regardless of the
 structure and how many tasks are involved, functions in the same isolation
 domain cannot run concurrently with each other.
 There will only ever be one task running synchronous code for any given

--- a/Guide.docc/DataRaceSafety.md
+++ b/Guide.docc/DataRaceSafety.md
@@ -60,11 +60,10 @@ see <doc:IncrementalAdoption#Dynamic-Isolation>
 ### Isolation Domains
 
 Data isolation is the _mechanism_ used to protect shared mutable state.
-But, it is often useful to talk about an independent unit of isolation.
+But it is often useful to talk about an independent unit of isolation.
 This is known as an _isolation domain_.
 How much state a particular domain is responsible for
-protecting can vary widely. An isolation domain might protect a single variable, 
-or an entire subsystem, like a complete user interface.
+protecting varies widely. An isolation domain might protect a single variable, or an entire subsystem, such as a user interface.
 
 The critical feature of an isolation domain is the safety it provides.
 Mutable state can only be accessed from one isolation domain at a time.
@@ -119,7 +118,7 @@ class Chicken {
 
 This is an example of a non-isolated type.
 Inheritance can play a role in static isolation.
-But, this simple class, with no superclass or protocol conformances,
+But this simple class, with no superclass or protocol conformances,
 also uses the default isolation.
 
 Data isolation guarantees that non-isolated entities cannot access the mutable
@@ -246,7 +245,7 @@ automatically based on context.
 Task isolation, just like all other Swift code, determines what mutable state
 they can access.
 
-Tasks can run both synchronous and asynchronous code. But, regardless of the
+Tasks can run both synchronous and asynchronous code. But regardless of the
 structure and how many tasks are involved, functions in the same isolation
 domain cannot run concurrently with each other.
 There will only ever be one task running synchronous code for any given
@@ -260,7 +259,7 @@ The Swift Programming Language.
 ### Isolation Inference and Inheritance
 
 There are many ways to specify isolation explicitly.
-But, there are cases where the context of a declaration will establish isolation
+But there are cases where the context of a declaration establishes isolation
 implicitly, via _isolation inference_.
 
 #### Classes
@@ -386,7 +385,7 @@ The Swift Programming Language.
 
 ## Isolation Boundaries
 
-Isolation domains protect their mutable state. But, useful programs need more
+Isolation domains protect their mutable state, but useful programs need more
 than just protection. They have to communicate and coordinate,
 often by passing data back and forth.
 Moving values into or out of an isolation domain is known as crossing an
@@ -450,7 +449,7 @@ The Swift Programming Language.
 
 ### Actor-Isolated Types
 
-Actors are not value types. But, because they protect all of their state
+Actors are not value types, but because they protect all of their state
 in their own isolation domain,
 they are inherently safe to pass across boundaries.
 This makes all actor types implicitly `Sendable`, even if their properties
@@ -529,10 +528,9 @@ func stockUp() {
 ```
 
 Potential suspension points are marked in source code with the `await` keyword.
-Its presence indicates that the call might suspend at runtime.
-But, `await` does not force a suspension, and the function being called might
-only suspend under certain dynamic conditions.
-It's possible that a call marked with `await` doesn't actually suspend.
+Its presence indicates that the call might suspend at runtime, but `await` does not force a suspension. The function being called might
+suspend only under certain dynamic conditions.
+It's possible that a call marked with `await` will not actually suspend.
 
 ### Atomicity
 

--- a/Guide.docc/DataRaceSafety.md
+++ b/Guide.docc/DataRaceSafety.md
@@ -63,7 +63,8 @@ Data isolation is the _mechanism_ used to protect shared mutable state.
 But it is often useful to talk about an independent unit of isolation.
 This is known as an _isolation domain_.
 How much state a particular domain is responsible for
-protecting varies widely. An isolation domain might protect a single variable, or an entire subsystem, such as a user interface.
+protecting varies widely. An isolation domain might protect a single variable,
+or an entire subsystem, such as a user interface.
 
 The critical feature of an isolation domain is the safety it provides.
 Mutable state can only be accessed from one isolation domain at a time.

--- a/Guide.docc/IncrementalAdoption.md
+++ b/Guide.docc/IncrementalAdoption.md
@@ -66,7 +66,7 @@ checking violations. To understand and address these, see [Crossing Isolation Bo
 
 Expressing the isolation of your program statically, using annotations and
 other language constructs, is both powerful and concise.
-But, it can be difficult to introduce static isolation without updating
+But it can be difficult to introduce static isolation without updating
 all dependencies simultaneously.
 
 Dynamic isolation provides runtime mechanisms you can use as a fallback for
@@ -92,7 +92,7 @@ class WindowStyler {
 ```
 
 This `MainActor` isolation may be _logically_ correct.
-But, if this type is used in other unmigrated locations,
+But if this type is used in other unmigrated locations,
 adding static isolation here could require many additional changes.
 An alternative is to use dynamic isolation to help control the scope.
 
@@ -152,7 +152,7 @@ scope of changes gradual.
 ## Missing Annotations
 
 Dynamic isolation gives you tools to express isolation at runtime.
-But, you may also find you need to describe other concurrency properties
+But you may also find you need to describe other concurrency properties
 that are missing from unmigrated modules.
 
 ### Unmarked Sendable Closures
@@ -217,7 +217,7 @@ class PersonalTransportation {
 
 It's important to keep in mind that static isolation, being part of the type
 system, affects your public API.
-But, you can migrate your own modules in a way that improves their APIs for
+But you can migrate your own modules in a way that improves their APIs for
 Swift 6 *without* breaking any existing clients.
 
 Suppose the `WindowStyler` is public API.

--- a/Guide.docc/RuntimeBehavior.md
+++ b/Guide.docc/RuntimeBehavior.md
@@ -34,12 +34,11 @@ await withTaskGroup(of: Something.self) { group in
 }
 ```
 
-If you suspect you may be dealing with hundreds or thousands of items, it may be wasteful to enqueue them all immediately.
-Creating a task (in `addTask`) needs to allocate some memory for the task in order to suspend and execute.
-This amount of memory isn't too large, it can become significant if creating thousands of tasks which don't get to
-execute immediately but are just waiting until the executor gets to run them.
+If you expect to deal with hundreds or thousands of items, it might be inefficient to enqueue them all immediately.
+Creating a task (in `addTask`) allocates memory for the task in order to suspend and execute it.
+While the amount of memory for each task isn't large, it can be significant when creating thousands of tasks that won't execute immediately.
 
-When faced with such a situation, it may be beneficial to manually throttle the number of concurrently added tasks to the task group, as follows:
+When faced with such a situation, you can manually throttle the number of concurrently added tasks in the group, as follows:
 
 ```swift
 let lotsOfWork: [Work] = ... 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # The Swift Concurrency Migration Guide
 
-This repository contains the source for *The Swift Concurrency Migration Guide*,
+This repository contains the source for [The Swift Concurrency Migration Guide][scmg],
 which is built using [Swift-DocC][docc].
 
 ## Contributing
@@ -29,3 +29,4 @@ open the link that `docc` outputs to display a local preview in your browser.
 [contributing]: https://github.com/apple/swift-migration-guide/blob/main/CONTRIBUTING.md
 [docc]: https://github.com/apple/swift-docc
 [conduct]: https://www.swift.org/code-of-conduct
+[scmg]: https://www.swift.org/migration/documentation/migrationguide


### PR DESCRIPTION

- Link to the live version of the Swift Concurrency Migration Guide.

- As a rule, eliminate commas after 'But' when starting a sentence. I think this makes the documentation more declarative and less conversational.

- Also fixing some other typos and passages to make them IMO flow better.

I hope I'm not being too forward with these proposals. I have an editorial eye and I know it doesn't match everybody's but I think the proposals I'm making are pretty standard and consistent, for example, with Apple's documentation style.