### PR TITLE
Missing words / swapped word order / small grammar or style changes.

### DIFF
--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -7,8 +7,8 @@ The data isolation guarantees made by the compiler affect all Swift code.
 This means complete concurrency checking can surface latent issues,
 even in Swift 5 code that doesn't use any concurrency language features
 directly.
-And, with the Swift 6 language mode is on, some of these potential issues
-can become errors.
+With the Swift 6 language mode enabled, some of these potential issues
+can also become errors.
 
 After enabling complete checking, many projects can contain a large
 number of warnings and errors.
@@ -268,7 +268,7 @@ protocol Styler {
 #### Asynchronous Requirements
 
 For methods that implement synchronous protocol requirements, either the
-isolation of method must match the isolation of the requirement exactly,
+isolation of the method must match the isolation of the requirement exactly,
 or the method must be `nonisolated`, meaning it can be called from
 any isolation domain without risk of data races. Making a requirement
 asynchronous offers a lot more flexibility over the isolation in
@@ -483,7 +483,7 @@ func updateStyle(backgroundColor: ColorComponents) async {
 With the addition of this `@preconcurrency import`,
 `ColorComponents` remains non-`Sendable`.
 However, the compiler's behavior will be altered.
-When using the Swift 6 language mode, the produced here will be downgraded
+When using the Swift 6 language mode, the error produced here will be downgraded
 to a warning.
 The Swift 5 language mode will produce no diagnostics at all.
 

--- a/Guide.docc/IncrementalAdoption.md
+++ b/Guide.docc/IncrementalAdoption.md
@@ -291,7 +291,7 @@ NS_SWIFT_ASYNC_NAME
 NS_SWIFT_ASYNC_NOTHROW
 NS_SWIFT_UNAVAILABLE_FROM_ASYNC(msg)
 ```
-### Dealing missing isolation annotations in Objective-C libraries
+### Dealing with missing isolation annotations in Objective-C libraries
 
 While the SDKs and other Objective-C libraries make progress in adopting Swift concurrency,
 they will often go through the exercise of codifying contracts which were only explained in
@@ -332,8 +332,8 @@ NS_SWIFT_UI_ACTOR // SDK author annotated using MainActor in recent SDK audit
 ```
 
 This method's isolation was accidentally inferred as `@MainActor`, because of the annotation on the enclosing type.
-Although it has specifically documented different a threading strategy - it may or may not
-be invoked on the main actor - it missed to annotate these semantics on the method. 
+Although it has specifically documented a different threading strategy - it may or may not
+be invoked on the main actor - annotating these semantics on the method was accidentally missed. 
 
 This is an annotation problem in the fictional JetPackKit library. 
 Specifically, it is missing a `nonisolated` annotation on the method,
@@ -373,7 +373,7 @@ Such failure would include a similar backtrace to this:
     frame #12: 0x00000001005..... libsystem_pthread.dylib`_pthread_wqthread + 228
 ```
 
-> Note: When encountering such issue, and by investigating the documentation and API annotations you determine something
+> Note: When encountering such an issue, and by investigating the documentation and API annotations you determine something
 >  was incorrectly annotated, the best way to resolve the root cause of the problem is to report the issue back to the 
 >  library maintainer.
 


### PR DESCRIPTION
Some light copyediting.
 
Small edits to correct missing words or transposed word-order or in a couple of cases, slightly changed grammar.

Should fix #80