### PR TITLE
change to reference type to fix #73

### DIFF
--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -385,7 +385,12 @@ However, this solution will require some structural changes to `WindowStyler`
 that could spill out code that depends on it as well.
 
 ```swift
-struct CustomWindowStyle: Styler {
+// class with necessary superclass
+class CustomWindowStyle: UIStyler {
+}
+
+// now, the conformance is possible
+extension CustomWindowStyle: Styler {
     func applyStyle() {
     }
 }


### PR DESCRIPTION
This was a medium-sized typo. I expanded the example just a little to make what's going on more explict.