### PR TITLE
Propose topic groups for outline

### DIFF
--- a/Guide.docc/MigrationGuide.md
+++ b/Guide.docc/MigrationGuide.md
@@ -59,4 +59,7 @@ full code examples, and learn about how to contribute in the [repository][].
 - <doc:CompleteChecking>
 - <doc:IncrementalAdoption>
 - <doc:CommonProblems>
+
+### Swift Concurrency in Depth
+
 - <doc:RuntimeBehavior>


### PR DESCRIPTION
The goal here being to not "scare" developers with too many topics up front.

There's far less to just "update to swift 6" than there is completely understanding all the edge cases etc. Some of the topics we want to explain here fall into the latter category, and will eventually maybe move somewhere else - but for now it's useful to separate them out so the path to "swift 6 adoption" does not look overwhelming.

![Screenshot 2024-06-18 at 11 37 18](https://github.com/apple/swift-migration-guide/assets/120979/243646cc-dcbb-4eec-8705-567ad58f0852)


WDYT about the topic group names?