### PR TITLE
fix #87; remove reference to a non-isolated domain

### DIFF
--- a/Guide.docc/DataRaceSafety.md
+++ b/Guide.docc/DataRaceSafety.md
@@ -86,7 +86,6 @@ These domains will always fall into one of three categories:
 Functions and variables do not have to be a part of an explicit isolation
 domain.
 In fact, a lack of isolation is the default, called _non-isolated_.
-This absence of isolation behaves just like a domain all to itself.
 Because all the data isolation rules apply,
 there is no way for non-isolated code to mutate state protected in another
 domain.


### PR DESCRIPTION
At best, this adds nothing meaningful. At worst, it is technically wrong and confusing. Let's just get rid of it.