### PR TITLE
Add a `sending` example

### DIFF
--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -557,6 +557,25 @@ Here, it does not matter than `ColorComponents` is not `Sendable`.
 By using `@Sendable` function that can compute the value, the lack of
 sendability is side-stepped entirely.
 
+### Sending Argument
+
+The compiler will permit non-`Sendable` values to cross an isolation boundary
+if can can prove it can be done safely.
+Functions that explicitly state they require this can use the values
+within their implementations with less restrictions.
+
+```swift
+func updateStyle(backgroundColor: sending ColorComponents) async {
+    // this boundary crossing can now be proven safe in all cases
+    await applyBackground(backgroundColor)
+}
+```
+
+A `sending` argument does impose some restrictions at call sites.
+But, this can still be easier or more appropriate than adding a
+`Sendable` conformance.
+This technique also works for types you do not control.
+
 ### Sendable Conformance
 
 When encountering problems related to crossing isolation domains, a very

--- a/Sources/Examples/Boundaries.swift
+++ b/Sources/Examples/Boundaries.swift
@@ -60,6 +60,13 @@ func computedValue_updateStyle(using backgroundColorProvider: @Sendable () -> Co
 #endif
 }
 
+#if swift(>=6.0)
+/// A function that uses a sending parameter to leverage region-based isolation.
+func sendingValue_updateStyle(backgroundColor: sending ColorComponents) async {
+    await applyBackground(backgroundColor)
+}
+#endif
+
 // MARK: Global Isolation
 /// An overload used by `globalActorIsolated_updateStyle` to match types.
 @MainActor
@@ -96,6 +103,13 @@ func exerciseBoundaryCrossingExamples() async {
     await computedValue_updateStyle(using: {
         ColorComponents()
     })
+
+#if swift(>=6.0)
+    print("  - enable region-based isolation with a sending argument")
+    let capturableComponents = ColorComponents()
+
+    await sendingValue_updateStyle(backgroundColor: capturableComponents)
+#endif
 
     print("  - using a globally-isolated type")
     let components = await GlobalActorIsolatedColorComponents()


### PR DESCRIPTION
I'm going through the written examples and trying to add them to the package. And I realized right away there was no `sending` example and we have to have one!