### PR TITLE
Make actor example more useful

### DIFF
--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -620,6 +620,21 @@ But further, data that is passed into or out of the actor may itself
 need to cross the isolation boundary.
 This can result in the need for yet more `Sendable` types.
 
+```swift
+actor Style {
+    private var background: ColorComponents
+
+    func applyBackground(_ color: ColorComponents) {
+        // make use of non-Sendable data here
+    }
+}
+```
+
+By moving both the non-Sendable data *and* operations on that data into the
+actor, no isolation boundaries need to be crossed.
+This provides a `Sendable` interface to those operations that can be freely
+accessed from any asynchronous context.
+
 #### Manual Synchronization
 
 If you have a type that is already doing manual synchronization, you can

--- a/Sources/Examples/Boundaries.swift
+++ b/Sources/Examples/Boundaries.swift
@@ -81,9 +81,24 @@ func globalActorIsolated_updateStyle(backgroundColor: GlobalActorIsolatedColorCo
     applyBackground(backgroundColor)
 }
 
+// MARK: actor isolation
+
+/// An actor that assumes the responsibility of managing the non-Sendable data.
+actor Style {
+    private var background: ColorComponents
+
+    init(background: ColorComponents) {
+        self.background = background
+    }
+
+    func applyBackground() {
+        // make use of background here
+    }
+}
+
 func exerciseBoundaryCrossingExamples() async {
     print("Isolation Boundary Crossing Examples")
-    
+
 #if swift(<6.0)
     print("  - updateStyle(backgroundColor:) passing its argument unsafely")
 #endif
@@ -115,4 +130,11 @@ func exerciseBoundaryCrossingExamples() async {
     let components = await GlobalActorIsolatedColorComponents()
 
     await globalActorIsolated_updateStyle(backgroundColor: components)
+
+    print("  - using an actor")
+    let actorComponents = ColorComponents()
+
+    let actor = Style(background: actorComponents)
+
+    await actor.applyBackground()
 }


### PR DESCRIPTION
Expands the example to provide a potential solution that could actually work. It's been correctly noted that these examples are too MainActor-oriented. So, this is really contrived. But, I think this is definitely more educational than leaving it as-is.

addresses #105