### PR TITLE
Add missing swift-testing example

### DIFF
--- a/Tests/Library/LibraryTests.swift
+++ b/Tests/Library/LibraryTests.swift
@@ -22,3 +22,18 @@ struct LibraryTest {
         await #expect(color.red == 1.0)
     }
 }
+
+extension LibraryTest {
+    @Test func testCallbackOperation() async {
+        await confirmation() { completion in
+            // function explicitly opts out of an generated async version
+            // so it requires a continuation here
+            await withCheckedContinuation { continuation in
+                JPKJetPack.jetPackConfiguration {
+                    completion()
+                    continuation.resume()
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I couldn't originally figure out how to do this. But, I now have it working and this matches the XCTest example here:

https://github.com/apple/swift-migration-guide/blob/caaafe528267a8a419b72c214b55f409b290a3d3/Tests/Library/LibraryXCTests.swift#L28