### PR TITLE
Turn on concurrency-related features for the 5 target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,8 @@ let package = Package(
             name: "Swift5Examples",
             dependencies: ["Library"],
             swiftSettings: [
-                .swiftLanguageVersion(.v5)
+                .swiftLanguageVersion(.v5),
+                .enableUpcomingFeature("StrictConcurrency"),
             ]
         ),
         .executableTarget(


### PR DESCRIPTION
I'm not sure how/why this ended up happening, but the Swift 5 target does not have complete checking enabled. This supresses the warnings the project is supposed to highlight 😅