### PR TITLE
Fix incorrect examples in IncrementalAdoption

### DIFF
--- a/Guide.docc/IncrementalAdoption.md
+++ b/Guide.docc/IncrementalAdoption.md
@@ -36,7 +36,7 @@ _continuations_.
 
 ```swift
 func updateStyle(backgroundColor: ColorComponents) async {
-    withCheckedContinuation { continuation in
+    await withCheckedContinuation { continuation in
         updateStyle(backgroundColor: backgroundColor) {
             // ... do some work here ...
 

--- a/Guide.docc/IncrementalAdoption.md
+++ b/Guide.docc/IncrementalAdoption.md
@@ -234,7 +234,7 @@ This code will compile without issue but crash at runtime.
 To workaround this, you can manually annotate the closure with `@Sendable.`
 This will prevent the compiler from inferring `MainActor` isolation.
 Because the compiler now knows actor isolation could change,
-it will require at await at the callsite.
+it will require a task at the callsite and an await in the task.
 
 ```swift
 @MainActor
@@ -243,7 +243,9 @@ class PersonalTransportation {
         JPKJetPack.jetPackConfiguration { @Sendable in
             // Sendable closures do not infer actor isolation,
             // making this context non-isolated
-            await self.applyConfiguration()
+            Task {
+                await self.applyConfiguration()
+            }
         }
     }
 


### PR DESCRIPTION
There are incorrect examples in IncrementalAdoption.
1. Missing an `await` keyword
2. Calling an async function in a synchronous closure

The second issue, in particular, misleads readers into thinking that an async function is available when @Sendable is attached to the closure.

In this PR, I have fixed these issues and updated the corresponding descriptions.