### PR TITLE
Fix typos in the Data Race Safety section

### DIFF
--- a/Guide.docc/DataRaceSafety.md
+++ b/Guide.docc/DataRaceSafety.md
@@ -493,7 +493,7 @@ func populate(island: Island, with chicken: sending Chicken) async {
 ```
 
 The compiler can now provide the guarantee that at all call sites, the
-`chicken` parameter will never be subject to unsafe acceses.
+`chicken` parameter will never be subject to unsafe access.
 This is a relaxing an otherwise significant constraint.
 Without `sending`, this function would only be possible to implement by
 requiring that `Chicken` first conform to `Sendable`.

--- a/Guide.docc/DataRaceSafety.md
+++ b/Guide.docc/DataRaceSafety.md
@@ -494,7 +494,7 @@ func populate(island: Island, with chicken: sending Chicken) async {
 
 The compiler can now provide the guarantee that at all call sites, the
 `chicken` parameter will never be subject to unsafe access.
-This is a relaxing an otherwise significant constraint.
+This is a relaxing of an otherwise significant constraint.
 Without `sending`, this function would only be possible to implement by
 requiring that `Chicken` first conform to `Sendable`.
 


### PR DESCRIPTION
Resolves a few typos under the "Flow-Sensitive Isolation Analysis" heading of the Data Race Safety section.

### Misspelled word
> the `chicken` parameter will never be subject to unsafe **acceses**.

Changed to:
> the `chicken` parameter will never be subject to unsafe **access**.

<hr>

### Missing word
> This is a relaxing an otherwise significant constraint.

Changed to:
> This is a relaxing **of** an otherwise significant constraint.