### PR TITLE
Replace deprecrated swiftLanguageVersion with swiftLanguageMode

### DIFF
--- a/Guide.docc/Swift6Mode.md
+++ b/Guide.docc/Swift6Mode.md
@@ -49,7 +49,7 @@ let package = Package(
         .target(
             name: "NotQuiteReadyYet",
             swiftSettings: [
-                .swiftLanguageVersion(.v5)
+                .swiftLanguageMode(.v5)
             ]
         )
     ]


### PR DESCRIPTION
Hey folks,
I noticed that `Enabling The Swift 6 Language Mode` still promotes deprecated mode naming, so here’s a fix.

For reference: https://github.com/swiftlang/swift-package-manager/pull/7620