### PR TITLE
Use only one single invocation, fix warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
             name: "Swift5Examples",
             dependencies:  ["Library", "ObjCLibrary"],
             swiftSettings: [
-                .swiftLanguageVersion(.v5),
+                .swiftLanguageMode(.v5),
                 .enableUpcomingFeature("StrictConcurrency"),
             ]
         ),

--- a/Sources/Examples/IncrementalMigration.swift
+++ b/Sources/Examples/IncrementalMigration.swift
@@ -28,7 +28,5 @@ func exerciseIncrementalMigrationExamples() async {
         let transport = JPKJetPack()
 
         await site.acceptTransport(transport)
-        await site.acceptTransport(transport)
-        await site.acceptTransport(transport)
     }
 }


### PR DESCRIPTION
The code was invoking `await site.acceptTransport(transport)` three times. I'm not sure why, but this results in a build error because after the first invocation, `transport` cannot be send to the actor again.

Also fixed up the use of `swiftLanguageVersion`, which has been deprecated.

