### PR TITLE
Change docc links to use `<doc:>`

### DIFF
--- a/Guide.docc/CommonProblems.md
+++ b/Guide.docc/CommonProblems.md
@@ -271,7 +271,7 @@ protocol using [`@preconcurrency`][Preconcurrency].
 This will preserve source compatibility with clients that have not yet
 begun adopting concurrency.
 
-[Preconcurrency]: libraryevolution#Preconcurrency-annotations
+[Preconcurrency]: <doc:LibraryEvolution#Preconcurrency-annotations>
 
 ```swift
 @preconcurrency @MainActor
@@ -343,7 +343,7 @@ of the conforming class is always enforced.
 > Note: To learn more about incremental adoption and dynamic isolation,
 see [Dynamic Isolation][]
 
-[Dynamic Isolation]: incrementaladoption#Dynamic-Isolation
+[Dynamic Isolation]: <doc:IncrementalAdoption#Dynamic-Isolation>
 
 ### Isolated Conforming Type
 

--- a/Guide.docc/IncrementalAdoption.md
+++ b/Guide.docc/IncrementalAdoption.md
@@ -66,7 +66,7 @@ APIs][continuation-apis] that exist to make interfacing non-async and async code
 > Note: Introducing asynchronous code into a project can surface data isolation
 checking violations. To understand and address these, see [Crossing Isolation Boundaries][]
 
-[Crossing Isolation Boundaries]: commonproblems#Crossing-Isolation-Boundaries
+[Crossing Isolation Boundaries]: <doc:CommonProblems#Crossing-Isolation-Boundaries>
 [continuation-apis]: https://developer.apple.com/documentation/swift/concurrency#continuations
 
 ## Dynamic Isolation
@@ -323,8 +323,8 @@ The `@preconcurrency` annotation can help with many of these situations:
 - [Non-Sendable types][]
 - Mismatches in [protocol-conformance isolation][]
 
-[Non-Sendable types]: commonproblems#Crossing-Isolation-Boundaries
-[protocol-conformance isolation]: commonproblems#Crossing-Isolation-Boundaries
+[Non-Sendable types]: <doc:CommonProblems#Non-Sendable-Types>
+[protocol-conformance isolation]: <doc:CommonProblems#Protocol-Conformance-Isolation-Mismatch>
 
 ## C/Objective-C
 


### PR DESCRIPTION
I noticed that links registered in the following format:
```markdown
[Preconcurrency]: libraryevolution#Preconcurrency-annotations
```
occasionally lead to incorrect paths, resulting in a 404 page.

- Correct URL: https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/incrementaladoption#Dynamic-Isolation
- Broken URL: https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/commonproblems/incrementaladoption#Dynamic-Isolation

To ensure consistent navigation, I have updated all such links to use the `<doc:>`.

- [x] Verified correct behavior by running `xcrun docc preview Guide.docc` in a local environment.