### PR TITLE
Add an abstract to the migration guide landing page

### DIFF
--- a/Guide.docc/MigrationGuide.md
+++ b/Guide.docc/MigrationGuide.md
@@ -1,5 +1,7 @@
 # Migrating to Swift 6
 
+Enable the Swift 6 language mode to eliminate data races at compile time, and adopt it incrementally across your project.
+
 @Metadata {
   @TechnologyRoot
 }


### PR DESCRIPTION
## Motivation

The migration guide's landing page goes straight from the title (`# Migrating to Swift 6`) to the `## Overview` section, so the built page — and its entry in the aggregated swift.org navigation — has no abstract summarizing what the guide covers.

This adds an abstract so that when the migration guide is included in a larger set of documentation content for Swift, what's included within this content clear.

## Changes

- Add a concise abstract directly after the title:

  > Enable the Swift 6 language mode to eliminate data races at compile time, and adopt it incrementally across your project.

No title or metadata change is needed — this is a `@TechnologyRoot` catalog whose title ("Migrating to Swift 6") already reads correctly.

## Validation

`docc convert Guide.docc --analyze` builds successfully, and the generated landing page now includes the abstract.